### PR TITLE
Core 252

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,10 @@ node_js:
 - '6'
 env:
   global:
-  # Please get your own free key if you want to test yourself
-  - BROWSERSTACK_USERNAME: << USERNAME GOES HERE >>
-  - BROWSERSTACK_ACCESS_KEY: << ACCESS KEY GOES HERE >>
-  - SAUCE_USERNAME: << USERNAME GOES HERE >>
-  - SAUCE_ACCESS_KEY: << ACCESS KEY GOES HERE >>
-cache:
-  directories:
-  - node_modules
+  - SAUCE_USERNAME: dojo2-ts-ci
+  - SAUCE_ACCESS_KEY: e92610e3-834e-4bec-a3b5-6f7b9d874601
+  - BROWSERSTACK_USERNAME: dtktestaccount1
+  - BROWSERSTACK_ACCESS_KEY: mG2qbEFJCZY2qLsM7yfx
 install:
 - travis_retry npm install grunt-cli
 - travis_retry npm install
@@ -21,3 +17,8 @@ script:
 - grunt intern:saucelabs --combined
 - grunt remapIstanbul:ci
 - grunt uploadCoverage
+- grunt dist
+notifications:
+  slack:
+    secure: mys3cAqs3gJ7HxLVhXMScDOZXCSdLsuVeMpAQXJ92/LxcMIS0wtIwaTqDox/n/U4tkhNEb1R3gJyEXBxeCu117umxX/aVNsR9HuZTXC+SjECwlPaan/qZkw7hSwqfwhEiGW4A8FGCA5OD+sq20ARpLZ718JrqzIYfSotpuJSHVg5OlfaCQIE3MdlpGjwJ0ZCxpsrVXVTmgFtxCmv8qmV24DcTnEQFmiXJftHhgi/npU/XdPAkdnjbS//iiWxV1vHiQagt0sVW3hxma5jzOaSHkiQQsJGNYCDCdLhzma3DDJoDS4sfznPMT08AQfSEzQiFhDIhNfJYVSbYjNbUq1O3xTSq83Lvdc/hQ1bLsYk7ZFqhWpRprijS6pYe/yp0TwlruzqTa5/a3qduCnc+ooMg72m1NxpUHiZG1NhD/IVz+ycEVt8P6yQpytXUsGiRGecmFJW0A0BrfrVcg7Ekwsr6Rmzxh4uKyXuOW7zTT3tn4CM1Q2fBZNXnQ9RlU7AIS3hiBIkv2SS89fuUrgTMEL9qDXF7zB4E9nc4mwvBM2YLHsdgiF+WSA1EERLxsYo9Ea3vtOUyjoi9A5EGKwHq7VAYEbEQfWYoDtIepSMmWCGjtDr3KI8oMdojkZdY0CrG7xGgruOX5QQQY6BEKTcgpW+ccVqjR5zB0Q8IZ04qhC5F+0=
+    on_success: change

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# dojo-streams
+# @dojo/streams
 
 [![Build Status](https://travis-ci.org/dojo/streams.svg?branch=master)](https://travis-ci.org/dojo/streams)
 [![codecov](https://codecov.io/gh/dojo/streams/branch/master/graph/badge.svg)](https://codecov.io/gh/dojo/streams)
-[![npm version](https://badge.fury.io/js/dojo-streams.svg)](http://badge.fury.io/js/dojo-streams)
+[![npm version](https://badge.fury.io/js/@dojo/streams.svg)](http://badge.fury.io/js/@dojo/streams)
 
 An implementation of the [WHATWG Streams Spec](https://streams.spec.whatwg.org/).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/dojo/streams.svg?branch=master)](https://travis-ci.org/dojo/streams)
 [![codecov](https://codecov.io/gh/dojo/streams/branch/master/graph/badge.svg)](https://codecov.io/gh/dojo/streams)
-[![npm version](https://badge.fury.io/js/@dojo/streams.svg)](http://badge.fury.io/js/@dojo/streams)
+[![npm version](https://badge.fury.io/js/%40dojo%2Fstreams.svg)](https://badge.fury.io/js/%40dojo%2Fstreams)
 
 An implementation of the [WHATWG Streams Spec](https://streams.spec.whatwg.org/).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dojo-streams",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-pre",
   "description": "An implementation of the streams standard.",
   "private": true,
   "homepage": "http://dojotoolkit.org",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dojo-streams",
-  "version": "2.0.0-pre",
+  "version": "2.0.0-alpha.1",
   "description": "An implementation of the streams standard.",
   "private": true,
   "homepage": "http://dojotoolkit.org",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/streams",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-pre",
   "description": "An implementation of the streams standard.",
   "private": true,
   "homepage": "http://dojotoolkit.org",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@dojo/loader": "2.0.0-beta.9",
     "grunt": "^1.0.1",
     "grunt-dojo2": ">=2.0.0-beta.19",
-    "intern": "^3.3.1",
+    "intern": "3.3.2",
     "istanbul": "0.4.3",
     "tslint": "^3.15.1",
     "typescript": "~2.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/streams",
-  "version": "2.0.0-pre",
+  "version": "2.0.0-alpha.2",
   "description": "An implementation of the streams standard.",
   "private": true,
   "homepage": "http://dojotoolkit.org",

--- a/package.json
+++ b/package.json
@@ -23,15 +23,15 @@
     "@dojo/shim": "2.0.0-beta.8"
   },
   "devDependencies": {
+    "@dojo/interfaces": "2.0.0-alpha.11",
+    "@dojo/loader": "2.0.0-beta.9",
     "@types/chai": "~3.4.0",
     "@types/formidable": "~1.0.0",
     "@types/glob": "~5.0.0",
     "@types/grunt": "~0.4.0",
-    "@dojo/interfaces": "2.0.0-alpha.11",
-    "@dojo/loader": "2.0.0-beta.9",
     "grunt": "^1.0.1",
     "grunt-dojo2": ">=2.0.0-beta.19",
-    "intern": "3.3.2",
+    "intern": "^3.4.2",
     "istanbul": "0.4.3",
     "tslint": "^3.15.1",
     "typescript": "~2.0.3"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dojo-streams",
+  "name": "@dojo/streams",
   "version": "2.0.0-pre",
   "description": "An implementation of the streams standard.",
   "private": true,
@@ -18,17 +18,17 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "dojo-core": "^2.0.0-alpha.16",
-    "dojo-has": ">=2.0.0-alpha.6",
-    "dojo-shim": ">=2.0.0-alpha.4"
+    "@dojo/core": "2.0.0-alpha.20",
+    "@dojo/has": "2.0.0-alpha.7",
+    "@dojo/shim": "2.0.0-beta.8"
   },
   "devDependencies": {
     "@types/chai": "~3.4.0",
     "@types/formidable": "~1.0.0",
     "@types/glob": "~5.0.0",
     "@types/grunt": "~0.4.0",
-    "dojo-interfaces": ">=2.0.0-alpha.2",
-    "dojo-loader": ">=2.0.0-beta.7",
+    "@dojo/interfaces": "2.0.0-alpha.11",
+    "@dojo/loader": "2.0.0-beta.9",
     "grunt": "^1.0.1",
     "grunt-dojo2": ">=2.0.0-beta.19",
     "intern": "^3.3.1",

--- a/src/ArraySink.ts
+++ b/src/ArraySink.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Sink } from './WritableStream';
 
 // Since this Sink is doing no asynchronous operations,

--- a/src/ArraySource.ts
+++ b/src/ArraySource.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Source } from './ReadableStream';
 import ReadableStreamController from './ReadableStreamController';
 

--- a/src/ReadableStream.ts
+++ b/src/ReadableStream.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Strategy } from './interfaces';
 import ReadableStreamController from './ReadableStreamController';
 import ReadableStreamReader from './ReadableStreamReader';

--- a/src/ReadableStreamReader.ts
+++ b/src/ReadableStreamReader.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import ReadableStream, { State } from './ReadableStream';
 
 interface ReadRequest<T> {

--- a/src/SeekableStream.ts
+++ b/src/SeekableStream.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Strategy } from './interfaces';
 import ReadableStream, { Source } from './ReadableStream';
 import { ReadResult } from './ReadableStreamReader';

--- a/src/SeekableStreamReader.ts
+++ b/src/SeekableStreamReader.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import ReadableStreamReader, { ReadResult } from './ReadableStreamReader';
 import SeekableStream from './SeekableStream';
 

--- a/src/TransformStream.ts
+++ b/src/TransformStream.ts
@@ -1,7 +1,7 @@
 // This is a simple adaptation to TypeScript of the reference implementation (as of May 2015):
 // https://github.com/whatwg/streams/blob/master/reference-implementation/lib/transform-stream.js
 
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Strategy } from './interfaces';
 import ReadableStream, { Source } from './ReadableStream';
 import ReadableStreamController from './ReadableStreamController';

--- a/src/WritableStream.ts
+++ b/src/WritableStream.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Strategy } from './interfaces';
 import SizeQueue from './SizeQueue';
 import * as util from './util';

--- a/src/adapters/EventedStreamSource.ts
+++ b/src/adapters/EventedStreamSource.ts
@@ -1,7 +1,7 @@
-import Promise from 'dojo-shim/Promise';
-import Evented from 'dojo-core/Evented';
-import { Handle } from 'dojo-interfaces/core';
-import on, { EventEmitter } from 'dojo-core/on';
+import Promise from '@dojo/shim/Promise';
+import Evented from '@dojo/core/Evented';
+import { Handle } from '@dojo/interfaces/core';
+import on, { EventEmitter } from '@dojo/core/on';
 import { Source } from '../ReadableStream';
 import ReadableStreamController from '../ReadableStreamController';
 

--- a/src/adapters/ReadableNodeStreamSource.ts
+++ b/src/adapters/ReadableNodeStreamSource.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Source } from '../ReadableStream';
 import ReadableStreamController from '../ReadableStreamController';
 import { Readable } from 'stream';

--- a/src/adapters/WritableNodeStreamSink.ts
+++ b/src/adapters/WritableNodeStreamSink.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Sink } from '../WritableStream';
 
 export type NodeSourceType = Buffer | string;

--- a/src/pipeToStream.ts
+++ b/src/pipeToStream.ts
@@ -1,7 +1,7 @@
-import { Response, DataEvent } from 'dojo-core/request';
-import { NodeResponse } from 'dojo-core/request/providers/node';
 import WritableStream from './WritableStream';
-import Promise from 'dojo-shim/Promise';
+import { Response, DataEvent } from '@dojo/core/request';
+import { NodeResponse } from '@dojo/core/request/providers/node';
+import Promise from '@dojo/shim/Promise';
 
 export default function pipeToStream<T>(response: Response, stream: WritableStream<T>): Promise<WritableStream<T>> {
 	return new Promise<WritableStream<T>>((resolve) => {

--- a/src/pipeToStream.ts
+++ b/src/pipeToStream.ts
@@ -1,0 +1,22 @@
+import { Response, DataEvent } from 'dojo-core/request';
+import { NodeResponse } from 'dojo-core/request/providers/node';
+import WritableStream from './WritableStream';
+import Promise from 'dojo-shim/Promise';
+
+export default function pipeToStream<T>(response: Response, stream: WritableStream<T>): Promise<WritableStream<T>> {
+	return new Promise<WritableStream<T>>((resolve) => {
+		response.on('data', (event: DataEvent) => {
+			stream.write(event.chunk);
+		});
+
+		response.on('end', () => {
+			stream.close();
+			resolve(stream);
+		});
+
+		// don't want to save the body because the file could be huge
+		if (response instanceof NodeResponse) {
+			response.downloadBody = false;
+		}
+	});
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Strategy } from './interfaces';
 
 /*

--- a/tests/intern-saucelabs.ts
+++ b/tests/intern-saucelabs.ts
@@ -6,8 +6,8 @@ export const environments = [
 	{ browserName: 'firefox', platform: 'Windows 10' },
 	{ browserName: 'chrome', platform: 'Windows 10' },
 	{ browserName: 'safari', version: '9', platform: 'OS X 10.11' },
-	{ browserName: 'android', deviceName: 'Google Nexus 7 HD Emulator' },
-	{ browserName: 'iphone', version: '7.1' }
+	// { browserName: 'android', deviceName: 'Google Nexus 7 HD Emulator' },
+	{ browserName: 'iphone', version: '9.3' }
 ];
 
 /* SauceLabs supports more max concurrency */

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -12,7 +12,7 @@ export const proxyUrl = 'http://localhost:9000/';
 export const capabilities = {
 	'browserstack.debug': false,
 	project: 'Dojo 2',
-	name: 'dojo-<< package-name >>'
+	name: '@dojo/<< package-name >>'
 };
 
 // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
@@ -42,8 +42,8 @@ export const initialBaseUrl: string | null = (function () {
 // The desired AMD loader to use when running unit tests (client.html/client.js). Omit to use the default Dojo
 // loader
 export const loaders = {
-	'host-browser': 'node_modules/dojo-loader/loader.js',
-	'host-node': 'dojo-loader'
+	'host-browser': 'node_modules/@dojo/loader/loader.js',
+	'host-node': '@dojo/loader'
 };
 
 // Configuration options for the module loader; any AMD configuration options supported by the specified AMD loader

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -12,7 +12,7 @@ export const proxyUrl = 'http://localhost:9000/';
 export const capabilities = {
 	'browserstack.debug': false,
 	project: 'Dojo 2',
-	name: '@dojo/<< package-name >>'
+	name: '@dojo/streams'
 };
 
 // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
@@ -53,7 +53,8 @@ export const loaderOptions = {
 	packages: [
 		{ name: 'src', location: '_build/src' },
 		{ name: 'tests', location: '_build/tests' },
-		{ name: 'dojo', location: 'node_modules/intern/node_modules/dojo' }
+		{ name: 'dojo', location: 'node_modules/intern/node_modules/dojo' },
+		{ name: '@dojo', location: 'node_modules/@dojo' }
 	]
 };
 

--- a/tests/unit/ByteLengthQueuingStrategy.ts
+++ b/tests/unit/ByteLengthQueuingStrategy.ts
@@ -1,6 +1,6 @@
 import * as assert from 'intern/chai!assert';
 import * as registerSuite from 'intern!object';
-import has from 'dojo-has/has';
+import has from '@dojo/has/has';
 import ByteLengthQueuingStrategy from '../../src/ByteLengthQueuingStrategy';
 import WritableStream, { State } from '../../src/WritableStream';
 import ManualSink from './helpers/ManualSink';

--- a/tests/unit/ReadableStream.ts
+++ b/tests/unit/ReadableStream.ts
@@ -7,7 +7,7 @@ import OriginalReadableStream, { State } from '../../src/ReadableStream';
 import ReadableStreamController from '../../src/ReadableStreamController';
 import { ReadResult } from '../../src/ReadableStreamReader';
 import { Strategy } from '../../src/interfaces';
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import TransformStream, { Transform } from '../../src/TransformStream';
 import WritableStream, { State as WritableState } from '../../src/WritableStream';
 

--- a/tests/unit/ReadableStreamReader.ts
+++ b/tests/unit/ReadableStreamReader.ts
@@ -1,4 +1,4 @@
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import ReadableStream, { State } from '../../src/ReadableStream';
 
 interface ReadRequest<T> {

--- a/tests/unit/SeekableStream.ts
+++ b/tests/unit/SeekableStream.ts
@@ -3,7 +3,7 @@ import * as registerSuite from 'intern!object';
 
 import ArraySource from '../../src/ArraySource';
 import CountQueuingStrategy from '../../src/CountQueuingStrategy';
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { State } from '../../src/ReadableStream';
 import { ReadResult } from '../../src/ReadableStreamReader';
 import SeekableStream from '../../src/SeekableStream';

--- a/tests/unit/TransformStream.ts
+++ b/tests/unit/TransformStream.ts
@@ -1,7 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import { Strategy } from '../../src/interfaces';
 import { State as ReadableState } from '../../src/ReadableStream';
 import ReadableStreamReader, { ReadResult } from '../../src/ReadableStreamReader';

--- a/tests/unit/WritableStream.ts
+++ b/tests/unit/WritableStream.ts
@@ -4,7 +4,7 @@ import WritableStream, { State, Sink } from '../../src/WritableStream';
 import BaseStringSink from './helpers/BaseStringSink';
 import ManualSink from './helpers/ManualSink';
 import { Strategy } from '../../src/interfaces';
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 
 const ASYNC_TIMEOUT = 1000;
 let stream: WritableStream<string>;

--- a/tests/unit/adapters/EventedStreamSource.ts
+++ b/tests/unit/adapters/EventedStreamSource.ts
@@ -1,7 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 
-import Evented from 'dojo-core/Evented';
+import Evented from '@dojo/core/Evented';
 import ReadableStream from '../../../src/ReadableStream';
 import ReadableStreamReader, { ReadResult } from '../../../src/ReadableStreamReader';
 import EventedStreamSource from '../../../src/adapters/EventedStreamSource';

--- a/tests/unit/adapters/ReadableNodeStreamSource.ts
+++ b/tests/unit/adapters/ReadableNodeStreamSource.ts
@@ -1,7 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { Readable } from 'stream';
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 import ReadableStream from '../../../src/ReadableStream';
 import { ReadResult } from '../../../src/ReadableStreamReader';
 import ReadableStreamController from '../../../src/ReadableStreamController';

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,5 +1,6 @@
 import './ByteLengthQueuingStrategy';
 import './CountQueuingStrategy';
+import './pipeToStream';
 import './ReadableStream';
 import './ReadableStreamController';
 import './ReadableStreamReader';

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -10,4 +10,4 @@ import './util';
 import './WritableStream';
 import './adapters/EventedStreamSource';
 
-import 'dojo/has!host-node?./nodeOnly:';
+import '@dojo/has/has!host-node?./nodeOnly:';

--- a/tests/unit/helpers/BaseStringSink.ts
+++ b/tests/unit/helpers/BaseStringSink.ts
@@ -1,5 +1,5 @@
 import { Sink } from '../../../src/WritableStream';
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 
 export default class BaseStringSink implements Sink<string> {
 

--- a/tests/unit/helpers/BaseStringSource.ts
+++ b/tests/unit/helpers/BaseStringSource.ts
@@ -1,6 +1,6 @@
 import ReadableStreamController from '../../../src/ReadableStreamController';
 import { Source } from '../../../src/ReadableStream';
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 
 export default class BaseStringSource implements Source<string> {
 

--- a/tests/unit/helpers/ManualSink.ts
+++ b/tests/unit/helpers/ManualSink.ts
@@ -1,5 +1,5 @@
 import { Sink } from '../../../src/WritableStream';
-import Promise from 'dojo-shim/Promise';
+import Promise from '@dojo/shim/Promise';
 
 // A sink whose write operations must be manually resolved by calling 'next'
 export default class ManualSink<T> implements Sink<T> {

--- a/tests/unit/pipeToStream.ts
+++ b/tests/unit/pipeToStream.ts
@@ -1,9 +1,9 @@
 import * as assert from 'intern/chai!assert';
 import * as registerSuite from 'intern!object';
 import pipeToStream from '../../src/pipeToStream';
-import { Headers, Response } from 'dojo-core/request';
-import { queueTask } from 'dojo-core/queue';
-import Task from 'dojo-core/async/Task';
+import { Headers, Response } from '@dojo/core/request';
+import { queueTask } from '@dojo/core/queue';
+import Task from '@dojo/core/async/Task';
 import ArraySink from '../../src/ArraySink';
 import WritableStream from '../../src/WritableStream';
 

--- a/tests/unit/pipeToStream.ts
+++ b/tests/unit/pipeToStream.ts
@@ -1,0 +1,91 @@
+import * as assert from 'intern/chai!assert';
+import * as registerSuite from 'intern!object';
+import pipeToStream from '../../src/pipeToStream';
+import { Headers, Response } from 'dojo-core/request';
+import { queueTask } from 'dojo-core/queue';
+import Task from 'dojo-core/async/Task';
+import ArraySink from '../../src/ArraySink';
+import WritableStream from '../../src/WritableStream';
+
+class MockResponse extends Response {
+	data: string[];
+
+	constructor(data: string[]) {
+		super();
+
+		this.data = data;
+
+		queueTask(() => {
+			data.forEach(chunk => {
+				this.emit({
+					type: 'data',
+					response: this,
+					chunk
+				});
+			});
+
+			this.emit({
+				type: 'end',
+				response: this
+			});
+		});
+	}
+
+	get bodyUsed(): boolean {
+		return false;
+	}
+
+	get headers(): Headers {
+		return new Headers();
+	}
+
+	get ok(): boolean {
+		return true;
+	}
+
+	get status(): number {
+		return 200;
+	}
+
+	get statusText(): string {
+		return 'OK';
+	}
+
+	get url(): string {
+		return '';
+	}
+
+	arrayBuffer(): Task<ArrayBuffer> {
+		return <any> null;
+	}
+
+	blob(): Task<Blob> {
+		return <any> null;
+	}
+
+	formData(): Task<FormData> {
+		return <any> null;
+	}
+
+	text(): Task<string> {
+		return <any> null;
+	}
+}
+
+registerSuite({
+	name: 'pipeToStream',
+
+	'sends data to stream'() {
+		const response = new MockResponse([
+			'bit 1',
+			'bit 2'
+		]);
+
+		const sink = new ArraySink<string>();
+		const stream = new WritableStream<string>(sink);
+
+		return pipeToStream(response, stream).then(() => {
+			assert.deepEqual(sink.chunks, [ 'bit 1', 'bit 2' ]);
+		});
+	}
+});

--- a/typings.json
+++ b/typings.json
@@ -1,11 +1,9 @@
 {
 	"name": "dojo-streams",
-	"globalDevDependencies": {
-		"digdug": "github:dojo/typings/custom/digdug/digdug.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"dojo2": "github:dojo/typings/custom/dojo2/dojo.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1",
-		"intern": "github:dojo/typings/custom/intern/intern.d.ts#122b1902bdbdb7b94bdee35bbc27bc6747e1979d",
-		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#840dfb52b52ec130e0ab2625663c68387adf1377",
+	"globalDependencies": {
 		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#9a0185f465a3febe2bb1ff3f1210f43e5f96c5d2"
+	},
+	"globalDevDependencies": {
+		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1"
 	}
 }


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This adds a utility method for streaming the new `dojo-core/request` to an HTTP stream.

Example usage,

```ts
request('http://www.example.com').then(response => {
    return pipeToStream(response, someStream);
}).then(() => {
    // do something with someStream, which has been closed
});
```

Resolves core #252
